### PR TITLE
Add enemy spawn sequence

### DIFF
--- a/Assets/Scripts/BaseEntity.cs
+++ b/Assets/Scripts/BaseEntity.cs
@@ -17,11 +17,15 @@ public class BaseEntity : MonoBehaviour
     public float attackSpeed = 1f; //Attacks per second
     public float movementSpeed = 1f; //Attacks per second
 
+    [Tooltip("Blood gained when sacrificed")]
+    public int bloodValue = 1;
+
     protected Team myTeam;
     protected BaseEntity currentTarget = null;
     protected Node currentNode;
 
     public Node CurrentNode => currentNode;
+    public Team Team => myTeam;
      
     protected bool HasEnemy => currentTarget != null;
     protected bool IsInRange => currentTarget != null && Vector3.Distance(this.transform.position, currentTarget.transform.position) <= range;
@@ -114,7 +118,7 @@ public class BaseEntity : MonoBehaviour
                 return;
 
             var path = GridManager.Instance.GetPath(currentNode, destination);
-            if (path == null && path.Count >= 1)
+            if (path == null || path.Count < 1)
                 return;
 
             if (path[1].IsOccupied)

--- a/Assets/Scripts/EntitiesDatabaseSO.cs
+++ b/Assets/Scripts/EntitiesDatabaseSO.cs
@@ -13,7 +13,10 @@ public class EntitiesDatabaseSO : ScriptableObject
         public Sprite icon;
 
         public int cost;
+        [Tooltip("Blood required to play this card")]
+        public int bloodCost;
     }
 
     public List<EntityData> allEntities;
 }
+

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -16,15 +16,21 @@ public class GameManager : Manager<GameManager>
     List<BaseEntity> team1Entities = new List<BaseEntity>();
     List<BaseEntity> team2Entities = new List<BaseEntity>();
 
-    int unitsPerTeam = 6;
+    int unitsPerTeam = 4;
 
-    public void OnEntityBought(EntitiesDatabaseSO.EntityData entityData)
+    [Header("Enemy Spawn")] 
+    public List<EntitiesDatabaseSO.EntityData> enemySpawnSequence = new List<EntitiesDatabaseSO.EntityData>();
+    public float enemySpawnDelay = 2f;
+
+    int enemySpawnIndex = 0;
+
+    public void OnEntityBought(EntitiesDatabaseSO.EntityData entityData, int lane = 0)
     {
         BaseEntity newEntity = Instantiate(entityData.prefab, team1Parent);
         newEntity.gameObject.name = entityData.name;
         team1Entities.Add(newEntity);
 
-        newEntity.Setup(Team.Team1, GridManager.Instance.GetFreeNode(Team.Team1));
+        newEntity.Setup(Team.Team1, GridManager.Instance.GetFreeNode(Team.Team1, lane));
     }
 
     public List<BaseEntity> GetEntitiesAgainst(Team against)
@@ -45,6 +51,43 @@ public class GameManager : Manager<GameManager>
         Destroy(entity.gameObject);
     }
 
+    public List<BaseEntity> GetTeamEntities(Team team)
+    {
+        return team == Team.Team1 ? team1Entities : team2Entities;
+    }
+
+    public void SacrificeUnit(BaseEntity entity)
+    {
+        if (entity == null || entity.Team != Team.Team1)
+            return;
+
+        PlayerData.Instance.AddBlood(entity.bloodValue);
+        UnitDead(entity);
+    }
+
+    private void Start()
+    {
+        if (enemySpawnSequence.Count > 0)
+            StartCoroutine(SpawnEnemies());
+    }
+
+    IEnumerator SpawnEnemies()
+    {
+        while (enemySpawnIndex < enemySpawnSequence.Count)
+        {
+            SpawnEnemy(enemySpawnSequence[enemySpawnIndex], enemySpawnIndex % GridManager.Instance.laneCount);
+            enemySpawnIndex++;
+            yield return new WaitForSeconds(enemySpawnDelay);
+        }
+    }
+
+    void SpawnEnemy(EntitiesDatabaseSO.EntityData data, int lane)
+    {
+        BaseEntity newEntity = Instantiate(data.prefab, team2Parent);
+        team2Entities.Add(newEntity);
+        newEntity.Setup(Team.Team2, GridManager.Instance.GetFreeNode(Team.Team2, lane));
+    }
+
 
     public void DebugFight()
     {
@@ -55,7 +98,7 @@ public class GameManager : Manager<GameManager>
 
             team2Entities.Add(newEntity);
 
-            newEntity.Setup(Team.Team2, GridManager.Instance.GetFreeNode(Team.Team2));
+            newEntity.Setup(Team.Team2, GridManager.Instance.GetFreeNode(Team.Team2, i % 4));
         }
     }
 }

--- a/Assets/Scripts/Graph.cs
+++ b/Assets/Scripts/Graph.cs
@@ -39,9 +39,9 @@ public class Graph
         return result;
     }
 
-    public void AddNode(Vector3 worldPosition)
+    public void AddNode(Vector3 worldPosition, int lane = 0)
     {
-        nodes.Add(new Node(nodes.Count, worldPosition));
+        nodes.Add(new Node(nodes.Count, worldPosition, lane));
     }
 
     public void AddEdge(Node from, Node to)
@@ -140,13 +140,15 @@ public class Node
 {
     public int index;
     public Vector3 worldPosition;
+    public int lane;
 
     private bool occupied = false;
 
-    public Node(int index, Vector3 worldPosition)
+    public Node(int index, Vector3 worldPosition, int lane = 0)
     {
         this.index = index;
         this.worldPosition = worldPosition;
+        this.lane = lane;
         occupied = false;
     }
 

--- a/Assets/Scripts/GridManager.cs
+++ b/Assets/Scripts/GridManager.cs
@@ -5,8 +5,10 @@ using UnityEngine;
 using UnityEngine.Tilemaps;
 
 public class GridManager : Manager<GridManager>
-{  
+{
     public GameObject terrainGrid;
+
+    public int laneCount = 4;
 
     protected Graph graph;
     protected Dictionary<Team, int> startPositionPerTeam;
@@ -25,26 +27,31 @@ public class GridManager : Manager<GridManager>
 
     public Node GetFreeNode(Team forTeam)
     {
+        for (int lane = 0; lane < laneCount; lane++)
+        {
+            Node n = GetFreeNode(forTeam, lane);
+            if (n != null)
+                return n;
+        }
+        return null;
+    }
+
+    public Node GetFreeNode(Team forTeam, int lane)
+    {
         int startIndex = startPositionPerTeam[forTeam];
+        int direction = startIndex == 0 ? 1 : -1;
         int currentIndex = startIndex;
 
-        while(graph.Nodes[currentIndex].IsOccupied)
+        while (currentIndex >= 0 && currentIndex < graph.Nodes.Count)
         {
-            if(startIndex == 0)
-            {
-                currentIndex++;
-                if (currentIndex == graph.Nodes.Count)
-                    return null;
-            }
-            else
-            {
-                currentIndex--;
-                if (currentIndex == -1)
-                    return null;
-            }
-            
+            Node node = graph.Nodes[currentIndex];
+            if (node.lane == lane && !node.IsOccupied)
+                return node;
+
+            currentIndex += direction;
         }
-        return graph.Nodes[currentIndex];
+
+        return null;
     }
 
     public List<Node> GetPath(Node from, Node to)
@@ -79,7 +86,8 @@ public class GridManager : Manager<GridManager>
         for (int i = 0; i < allTiles.Count; i++)
         {
             Vector3 place = allTiles[i].transform.position;
-            graph.AddNode(place);
+            int lane = i % laneCount;
+            graph.AddNode(place, lane);
         }
 
         var allNodes = graph.Nodes;

--- a/Assets/Scripts/PlayerData.cs
+++ b/Assets/Scripts/PlayerData.cs
@@ -5,12 +5,14 @@ using UnityEngine;
 public class PlayerData : Manager<PlayerData>
 {
     public int Money { get; private set; }
+    public int Blood { get; private set; }
 
     public System.Action OnUpdate;
 
     private void Start()
     {
         Money = 250;
+        Blood = 0;
     }
 
     public bool CanAfford(int amount)
@@ -21,6 +23,23 @@ public class PlayerData : Manager<PlayerData>
     public void SpendMoney(int amount)
     {
         Money -= amount;
+        OnUpdate?.Invoke();
+    }
+
+    public bool CanPayBlood(int amount)
+    {
+        return amount <= Blood;
+    }
+
+    public void SpendBlood(int amount)
+    {
+        Blood -= amount;
+        OnUpdate?.Invoke();
+    }
+
+    public void AddBlood(int amount)
+    {
+        Blood += amount;
         OnUpdate?.Invoke();
     }
 }

--- a/Assets/Scripts/UIShop.cs
+++ b/Assets/Scripts/UIShop.cs
@@ -7,6 +7,7 @@ public class UIShop : MonoBehaviour
 {
     public List<UICard> allCards;
     public Text money;
+    public Text blood;
 
     private EntitiesDatabaseSO cachedDb;
     private int refreshCost = 1;
@@ -32,13 +33,28 @@ public class UIShop : MonoBehaviour
 
     public void OnCardClick(UICard card, EntitiesDatabaseSO.EntityData cardData)
     {
-        //We should check if we have the money!
-        if(PlayerData.Instance.CanAfford(cardData.cost))
+        if (!PlayerData.Instance.CanAfford(cardData.cost))
+            return;
+
+        if (!PlayerData.Instance.CanPayBlood(cardData.bloodCost))
         {
-            PlayerData.Instance.SpendMoney(cardData.cost);
-            card.gameObject.SetActive(false);
-            GameManager.Instance.OnEntityBought(cardData);
+            int need = cardData.bloodCost - PlayerData.Instance.Blood;
+            var units = GameManager.Instance.GetTeamEntities(Team.Team1);
+            while (need > 0 && units.Count > 0)
+            {
+                GameManager.Instance.SacrificeUnit(units[0]);
+                need--;
+                units = GameManager.Instance.GetTeamEntities(Team.Team1);
+            }
+
+            if (!PlayerData.Instance.CanPayBlood(cardData.bloodCost))
+                return;
         }
+
+        PlayerData.Instance.SpendMoney(cardData.cost);
+        PlayerData.Instance.SpendBlood(cardData.bloodCost);
+        card.gameObject.SetActive(false);
+        GameManager.Instance.OnEntityBought(cardData, 0);
     }
 
     public void OnRefreshClick()
@@ -54,5 +70,7 @@ public class UIShop : MonoBehaviour
     void Refresh()
     {
         money.text = PlayerData.Instance.Money.ToString();
+        if (blood != null)
+            blood.text = PlayerData.Instance.Blood.ToString();
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
-# ok-auto-battle
-Code repository for the video tutorial serie : [Let's make an auto battle game with Unity!](https://www.youtube.com/playlist?list=PLOdqgw8ea-s7LGLXZt_bcTxTZHRfs6Km2)
-The repository will be kept up-to-date with the video serie 
+# Shan Hai Card Game
+
+This project is a 2D card based auto‑battler inspired by **Inscryption** and themed around the mythical creatures of the *Shan Hai Jing*. Units are represented by cards that can be sacrificed to play stronger ones and will automatically battle along four lanes. Cards now cost both money and **blood**, which you gain by sacrificing your own creatures.
+
+### Features
+
+* Four lane combat with automatic attacks each turn
+* "Blood" sacrifice system used to play stronger cards
+* Simple shop interface to buy and deploy new units
+* Enemy cards appear automatically following a preset queue
+
+## Getting Started
+
+1. Open the project with **Unity 2019.2** or newer.
+2. Load `Assets/Scenes/GameScene.unity` and press Play to try the current demo.
+
+## Credits
+
+This game was started from the tutorial series: [Let's make an auto battle game with Unity!](https://www.youtube.com/playlist?list=PLOdqgw8ea-s7LGLXZt_bcTxTZHRfs6Km2)


### PR DESCRIPTION
## Summary
- implement a simple queue to spawn enemy units automatically
- note the enemy spawn feature in README

## Testing
- `grep -n blood -n Assets/Scripts -r | head -n 20`
- `od -c Assets/Scripts/Graph.cs | tail -n 3`


------
https://chatgpt.com/codex/tasks/task_e_6840523591f8832b80b14915f5e5cbfc